### PR TITLE
fix: ESLint 설정 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,13 @@
     "quotes": "off",
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
-    "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx"] }]
+    "react/jsx-filename-extension": [
+      "error",
+      { "extensions": [".js", ".jsx"] }
+    ],
+    "react/no-unknown-property": "off"
+  },
+  "settings": {
+    "import/core-modules": ["@react-three/cannon"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "link",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/cannon": "^6.5.2",
         "@react-three/drei": "^9.57.3",
         "@react-three/fiber": "^8.12.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -3156,6 +3157,14 @@
         }
       }
     },
+    "node_modules/@pmndrs/cannon-worker-api": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@pmndrs/cannon-worker-api/-/cannon-worker-api-2.3.2.tgz",
+      "integrity": "sha512-+4YGTH7XfSvUYUa65LoltcDMRLu3lr7rFtHT9dmeCeu2JJ7Zg2xBFJ5wiWSJmcM1ECh2R0YDcROdEQ1JKpOgFA==",
+      "peerDependencies": {
+        "three": ">=0.139"
+      }
+    },
     "node_modules/@react-spring/animated": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.6.1.tgz",
@@ -3223,6 +3232,21 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.6.1.tgz",
       "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q=="
+    },
+    "node_modules/@react-three/cannon": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@react-three/cannon/-/cannon-6.5.2.tgz",
+      "integrity": "sha512-d7qH2XMVtHRkCaMUWpLkWSD9JPiE570gy8LoP7WBw+Ui+hI9ZiFx9HDaX5+Y6wzbGJd1WvELWaG9O0cOtk2rmw==",
+      "dependencies": {
+        "@pmndrs/cannon-worker-api": "^2.3.2",
+        "cannon-es": "^0.20.0",
+        "cannon-es-debugger": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8",
+        "react": ">=18",
+        "three": ">=0.139"
+      }
     },
     "node_modules/@react-three/drei": {
       "version": "9.57.3",
@@ -5924,6 +5948,26 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
+    },
+    "node_modules/cannon-es": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
+      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA=="
+    },
+    "node_modules/cannon-es-debugger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cannon-es-debugger/-/cannon-es-debugger-1.0.0.tgz",
+      "integrity": "sha512-sE9lDOBAYFKlh+0w+cvWKwUhJef8HYnUSVPWPL0jD15MAuVRQKno4QYZSGxgOoJkMR3mQqxL4bxys2b3RSWH8g==",
+      "peerDependencies": {
+        "cannon-es": "0.x",
+        "three": "0.x",
+        "typescript": ">=3.8"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@react-three/cannon": "^6.5.2",
     "@react-three/drei": "^9.57.3",
     "@react-three/fiber": "^8.12.0",
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
## 개요
ESLint가 React Three Fiber, Cannon과 호환하지 않는 문제 해결

## 작업 내용
1. ESLint 설정에 코어 모듈을 설정
```json
"settings": {
  "import/core-modules": ["@react-three/cannon"]
}
```

2. ESLint의 react/no-unknown-property 설정을 off로 변경
```json
"react/no-unknown-property": "off"
```

3. Cannon 디펜던시 추가

## 특이 사항
이슈 #1 