### PR TITLE
feat: 기본적인 Graph Path 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
       { "extensions": [".js", ".jsx"] }
     ],
     "react/no-unknown-property": "off",
-    "no-param-reassign": 0
+    "no-param-reassign": 0,
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
   },
   "settings": {
     "import/resolver": {

--- a/src/components/objects/Cube.js
+++ b/src/components/objects/Cube.js
@@ -1,12 +1,16 @@
-import { useBox } from "@react-three/cannon";
+import PropTypes from "prop-types";
 
-export default function Cube(props) {
-  const [ref] = useBox(() => ({ ...props }));
+export default function Cube({ position }) {
+  const color = "rgb(51, 153, 255)";
 
   return (
-    <mesh ref={ref}>
+    <mesh position={position}>
       <boxGeometry />
-      <meshStandardMaterial color="rgb(51, 153, 255)" />
+      <meshStandardMaterial color={color} />
     </mesh>
   );
 }
+
+Cube.propTypes = {
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+};

--- a/src/data/stageZeroCoordinates.json
+++ b/src/data/stageZeroCoordinates.json
@@ -1,4 +1,6 @@
 {
+  "departure": [0, 0.5, 1],
+  "arrival": [4, 0.5, 4],
   "cubes": {
     "positions": [
       [0, 4.5, 0],

--- a/src/redux/stageLevelSlice.js
+++ b/src/redux/stageLevelSlice.js
@@ -3,7 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const stageLevelSlice = createSlice({
   name: "stageLevel",
   initialState: {
-    level: 1,
+    level: 0,
   },
   reducers: {
     setLevel: (state, action) => {

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -1,0 +1,51 @@
+export default function Graph() {
+  this.nodes = new Map();
+}
+
+Graph.prototype.addNode = function (position) {
+  const node = JSON.stringify(position);
+
+  if (!this.nodes.has(node)) {
+    this.nodes.set(node, []);
+  }
+};
+
+Graph.prototype.addEdge = function (positionA, positionB) {
+  const nodeA = JSON.stringify(positionA);
+  const nodeB = JSON.stringify(positionB);
+
+  if (this.nodes.has(nodeA) && this.nodes.has(nodeB)) {
+    this.nodes.get(nodeA).push(nodeB);
+    this.nodes.get(nodeB).push(nodeA);
+  }
+};
+
+Graph.prototype.removeEdge = function (positionA, positionB) {
+  const nodeA = JSON.stringify(positionA);
+  const nodeB = JSON.stringify(positionB);
+
+  if (this.nodes.has(nodeA) && this.nodes.has(nodeB)) {
+    this.nodes.set(
+      nodeA,
+      this.nodes.get(nodeA).filter(edge => edge !== nodeB)
+    );
+    this.nodes.set(
+      nodeB,
+      this.nodes.get(nodeB).filter(edge => edge !== nodeA)
+    );
+  }
+};
+
+Graph.prototype.removeNode = function (position) {
+  const node = JSON.stringify(position);
+
+  if (this.nodes.has(node)) {
+    this.nodes.get(node).forEach(edgeNode => {
+      this.nodes.set(
+        edgeNode,
+        this.nodes.get(edgeNode).filter(edge => edge !== node)
+      );
+    });
+    this.nodes.delete(node);
+  }
+};

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,0 +1,54 @@
+import Graph from "./graph";
+
+function getPathPositions(playerPosition, positions) {
+  const path = positions.filter(position => {
+    const topCubePosition = [position[0], position[1] + 1, position[2]];
+
+    if (position[1] === playerPosition[1]) {
+      const hasTopCube = positions.some(
+        p =>
+          p[0] === topCubePosition[0] &&
+          p[1] === topCubePosition[1] &&
+          p[2] === topCubePosition[2]
+      );
+
+      if (!hasTopCube) return true;
+    }
+
+    return false;
+  });
+
+  return path;
+}
+
+function isNextPosition(positionA, positionB) {
+  const xAxisDiff = Math.abs(positionA[0] - positionB[0]);
+  const zAxisDiff = Math.abs(positionA[2] - positionB[2]);
+
+  return (
+    (xAxisDiff === 1 && zAxisDiff === 0) || (xAxisDiff === 0 && zAxisDiff === 1)
+  );
+}
+
+export default function createPath(playerPosition, positions) {
+  const pathPositions = getPathPositions(playerPosition, positions);
+  const graph = new Graph();
+
+  pathPositions.map(position => graph.addNode(position));
+
+  const nodesArray = Array.from(graph.nodes.keys());
+
+  for (let i = 0; i < nodesArray.length; i++) {
+    const nodeA = JSON.parse(nodesArray[i]);
+
+    for (let j = i + 1; j < nodesArray.length; j++) {
+      const nodeB = JSON.parse(nodesArray[j]);
+
+      if (isNextPosition(nodeA, nodeB)) {
+        graph.addEdge(nodeA, nodeB);
+      }
+    }
+  }
+
+  return graph;
+}


### PR DESCRIPTION
## 개요
- `Graph` 생성자 함수와 `addNode`, `addEdge`, `removeEdge`, `removeNode` 메소드 구현
- 플레이어 좌표에 따라 동일한 높이의 블럭 좌표만 찾는 `getPathPositions` 함수 구현
- 두 좌표의 `x`, `z`값을 비교해서 인접한 좌표인지 반환하는 `isNextPosition` 함수 구현
- 전체적인 path를 만드는 `createPath` 함수 구현
- for문 안에서 ++ 사용할 수 있도록 ESLint 설정 수정
- `Cube` components에 불필요한 `ref` 삭제하고 `position`으로 수정
- StageZero에 createPath 연결 (임시 연결로 no unused lint 주석 설정)
- stageZeroCoordinates.json 파일에 출발지, 도착지 좌표 추가

## 작업 내용

### Graph
- Path를 구현할 때 처음 양방향 연결 리스트를 생각했지만, 인접 블럭이 3개 이상일 때의 상황을 고려해서 이후 자료 구조를 Tree -> Graph까지 확장하게 되었습니다.
```javascript
export default function Graph() {
  this.nodes = new Map();
}
```
- 좌표끼리 연결, 연결 해제, 검색 등을 빠르게 하기 위해서 Graph nodes를 `map`으로 구현했습니다.
- position 배열을 `key`로 잡기 위해 `JSON.stringify`를 이용했습니다.
```javascript
const node = JSON.stringify(position);
```
- `edges`는 map의 array `value`로 구현했습니다.
```javascript
this.nodes.set(node, []);
```
- Graph 메소드 구현을 위해 `prototype`을 사용했고, `this` 설정을 위해 화살표 함수가 아닌 익명 함수로 구현했습니다.
- 현재 메소드는 `addNode`, `addEdge`, `removeEdge`, `removeNode`만 구현했습니다.

### getPathPositions
- 플레이어 현재 좌표와, 전체 스테이지 좌표를 인자로 받는 함수입니다.
- 플레이어 좌표와 높이(y)가 동일하면서 이동 가능한(위로 쌓인 블럭이 없는) 좌표만 반환하도록 구현했습니다.

### isNextPosition
- 두 개의 좌표를 인자로 받아 이어진 좌표인지 확인하는 함수입니다.
- x, z값 중 하나만 1 차이인지 확인하여 `Boolean`으로 반환합니다.

### createPath
- 플레이어 좌표, 전체 좌표를 받아서 위의 `Graph`, `getPathPositions`, `isNextPosition` 함수들을 이용해 최종 패스를 만드는 함수입니다.
- `getPathPositions`를 이용해 받은 좌표로 `Graph`를 생성하고,
반복문을 돌며 `isNextPosition`으로 인접한 좌표일 경우 `graph.addEdge` 메소드를 이용해 연결합니다.

<img width="340" alt="스크린샷 2023-03-21 오후 3 23 37" src="https://user-images.githubusercontent.com/106433812/226537266-31c7c7a1-a2b1-40e3-9c84-43327715cca2.png">

## 특이 사항
게임 스테이지에 따라 엣지 케이스가 있을 것 같은데, 일단 현재 나온 케이스로 구현했습니다.