### PR TITLE
feat: 엣지 링크에 따라 패스 추가 생성 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,9 @@
     ],
     "react/no-unknown-property": "off",
     "no-param-reassign": 0,
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "func-names": ["error", "never"]
   },
   "settings": {
     "import/resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^8.0.3",
-        "lint-staged": "^13.2.0"
+        "lint-staged": "^13.2.0",
+        "redux-logger": "^3.0.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7041,6 +7042,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
+    },
+    "node_modules/deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug==",
+      "dev": true
     },
     "node_modules/deep-equal": {
       "version": "2.2.0",
@@ -16022,6 +16029,15 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
+      "dev": true,
+      "dependencies": {
+        "deep-diff": "^0.3.5"
       }
     },
     "node_modules/redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
-    "lint-staged": "^13.2.0"
+    "lint-staged": "^13.2.0",
+    "redux-logger": "^3.0.6"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/src/components/stages/StageZero.js
+++ b/src/components/stages/StageZero.js
@@ -1,14 +1,32 @@
+import { useEffect, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Physics } from "@react-three/cannon";
 import { OrbitControls } from "@react-three/drei";
+import { useSelector } from "react-redux";
 
 import Cube from "../objects/Cube";
 import SkipMenu from "../menus/SkipMenu";
 import AutoSnap from "../../utils/AutoSnap";
 import PlayerObject from "../objects/PlayerObject";
 import stageZeroCoordinates from "../../data/stageZeroCoordinates.json";
+import { createPath, connectEdge } from "../../utils/path";
 
 export default function StageZero() {
+  const coordinates = stageZeroCoordinates.cubes.positions.map(
+    position => position.coordinate
+  );
+  const isLinked = useSelector(state => state.edgeLink.isLinked);
+  const currentLinkEdge = useSelector(state => state.edgeLink.linkEdge);
+  const [path, setPath] = useState(
+    createPath(stageZeroCoordinates.departure[1], coordinates)
+  );
+
+  useEffect(() => {
+    if (isLinked) {
+      setPath(connectEdge(path, currentLinkEdge, coordinates));
+    }
+  }, [isLinked]);
+
   return (
     <>
       <Canvas

--- a/src/data/stageZeroCoordinates.json
+++ b/src/data/stageZeroCoordinates.json
@@ -31,32 +31,6 @@
       },
       "color": "red",
       "thickness": 3
-    },
-    {
-      "id": "stageZero-linkEdge-2",
-      "edgeFrom": {
-        "pointA": [1, 5, 3.5],
-        "pointB": [1, 5, 4.5]
-      },
-      "edgeTo": {
-        "pointA": [1.5, 1, 1.5],
-        "pointB": [1.5, 1, 2.5]
-      },
-      "color": "green",
-      "thickness": 3
-    },
-    {
-      "id": "stageZero-linkEdge-3",
-      "edgeFrom": {
-        "pointA": [1, 8, 3.5],
-        "pointB": [1, 7, 3.5]
-      },
-      "edgeTo": {
-        "pointA": [6.5, 3, 2.5],
-        "pointB": [6.5, 2, 2.5]
-      },
-      "color": "orange",
-      "thickness": 3
     }
   ]
 }

--- a/src/redux/edgeLinkSlice.js
+++ b/src/redux/edgeLinkSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const edgeLinkSlice = createSlice({
+  name: "edgeLink",
+  initialState: {
+    isLink: false,
+    linkEdge: null,
+  },
+  reducers: {
+    setIsLink: (state, action) => {
+      state.isLink = action.payload;
+    },
+    setLinkEdge: (state, action) => {
+      state.linkEdge = action.payload;
+    },
+  },
+});
+
+export const { setIsLink, setLinkEdge } = edgeLinkSlice.actions;
+export default edgeLinkSlice.reducer;

--- a/src/redux/edgeLinkSlice.js
+++ b/src/redux/edgeLinkSlice.js
@@ -3,12 +3,12 @@ import { createSlice } from "@reduxjs/toolkit";
 const edgeLinkSlice = createSlice({
   name: "edgeLink",
   initialState: {
-    isLink: false,
+    isLinked: false,
     linkEdge: null,
   },
   reducers: {
-    setIsLink: (state, action) => {
-      state.isLink = action.payload;
+    setIsLinked: (state, action) => {
+      state.isLinked = action.payload;
     },
     setLinkEdge: (state, action) => {
       state.linkEdge = action.payload;
@@ -16,5 +16,5 @@ const edgeLinkSlice = createSlice({
   },
 });
 
-export const { setIsLink, setLinkEdge } = edgeLinkSlice.actions;
+export const { setIsLinked, setLinkEdge } = edgeLinkSlice.actions;
 export default edgeLinkSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,12 +1,17 @@
 import { configureStore } from "@reduxjs/toolkit";
+import logger from "redux-logger";
+
 import stageLevelReducer from "./stageLevelSlice";
 import screenModeSliceReducer from "./screenModeSlice";
+import edgeLinkSliceReducer from "./edgeLinkSlice";
 
 const store = configureStore({
   reducer: {
     stageLevel: stageLevelReducer,
     screenMode: screenModeSliceReducer,
+    edgeLink: edgeLinkSliceReducer,
   },
+  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
 });
 
 export default store;

--- a/src/utils/AutoSnap.js
+++ b/src/utils/AutoSnap.js
@@ -5,7 +5,7 @@ import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 
 import LinkAnglesCalculator from "./LinkAngleCalculator";
-import { setIsLink, setLinkEdge } from "../redux/edgeLinkSlice";
+import { setIsLinked, setLinkEdge } from "../redux/edgeLinkSlice";
 
 const throttled = (callback, delay) => {
   const lastRun = useRef(Date.now());
@@ -37,7 +37,7 @@ export default function AutoSnap({ linkSensitivity, linkEdge }) {
 
     if (prevInRange.current !== inRange) {
       prevInRange.current = inRange;
-      dispatch(setIsLink(inRange));
+      dispatch(setIsLinked(inRange));
       dispatch(setLinkEdge(linkEdge));
     }
   };

--- a/src/utils/AutoSnap.js
+++ b/src/utils/AutoSnap.js
@@ -1,23 +1,48 @@
+import { useRef } from "react";
 import { useThree, useFrame } from "@react-three/fiber";
 import { OrthographicCamera } from "@react-three/drei";
+import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 
 import LinkAnglesCalculator from "./LinkAngleCalculator";
+import { setIsLink, setLinkEdge } from "../redux/edgeLinkSlice";
+
+const throttled = (callback, delay) => {
+  const lastRun = useRef(Date.now());
+
+  useFrame(() => {
+    if (Date.now() - lastRun.current >= delay) {
+      callback();
+      lastRun.current = Date.now();
+    }
+  });
+};
 
 export default function AutoSnap({ linkSensitivity, linkEdge }) {
   const { camera } = useThree();
+  const dispatch = useDispatch();
+  const prevInRange = useRef(null);
   const linkAngles = LinkAnglesCalculator(linkEdge);
 
-  useFrame(() => {
-    if (
+  const checkCameraRotation = () => {
+    const inRange =
       camera.rotation.x > linkAngles.x - linkSensitivity &&
       camera.rotation.x < linkAngles.x + linkSensitivity &&
       camera.rotation.y > linkAngles.y - linkSensitivity &&
-      camera.rotation.y < linkAngles.y + linkSensitivity
-    ) {
+      camera.rotation.y < linkAngles.y + linkSensitivity;
+
+    if (inRange) {
       camera.rotation.set(linkAngles.x, linkAngles.y, camera.rotation.z);
     }
-  });
+
+    if (prevInRange.current !== inRange) {
+      prevInRange.current = inRange;
+      dispatch(setIsLink(inRange));
+      dispatch(setLinkEdge(linkEdge));
+    }
+  };
+
+  throttled(checkCameraRotation, 10);
 
   return (
     <OrthographicCamera

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -2,17 +2,17 @@ export default function Graph() {
   this.nodes = new Map();
 }
 
-Graph.prototype.addNode = function (position) {
-  const node = JSON.stringify(position);
+Graph.prototype.addNode = function (coordinates) {
+  const node = JSON.stringify(coordinates);
 
   if (!this.nodes.has(node)) {
     this.nodes.set(node, []);
   }
 };
 
-Graph.prototype.addEdge = function (positionA, positionB) {
-  const nodeA = JSON.stringify(positionA);
-  const nodeB = JSON.stringify(positionB);
+Graph.prototype.addEdge = function (coordinatesA, coordinatesB) {
+  const nodeA = JSON.stringify(coordinatesA);
+  const nodeB = JSON.stringify(coordinatesB);
 
   if (this.nodes.has(nodeA) && this.nodes.has(nodeB)) {
     this.nodes.get(nodeA).push(nodeB);
@@ -20,24 +20,24 @@ Graph.prototype.addEdge = function (positionA, positionB) {
   }
 };
 
-Graph.prototype.removeEdge = function (positionA, positionB) {
-  const nodeA = JSON.stringify(positionA);
-  const nodeB = JSON.stringify(positionB);
+Graph.prototype.removeEdge = function (coordinatesA, coordinatesB) {
+  const nodeA = JSON.stringify(coordinatesA);
+  const nodeB = JSON.stringify(coordinatesB);
 
   if (this.nodes.has(nodeA) && this.nodes.has(nodeB)) {
     this.nodes.set(
       nodeA,
-      this.nodes.get(nodeA).filter(edge => edge !== nodeB)
+      this.nodes.get(nodeA).filter(edgeNode => edgeNode !== nodeB)
     );
     this.nodes.set(
       nodeB,
-      this.nodes.get(nodeB).filter(edge => edge !== nodeA)
+      this.nodes.get(nodeB).filter(edgeNode => edgeNode !== nodeA)
     );
   }
 };
 
-Graph.prototype.removeNode = function (position) {
-  const node = JSON.stringify(position);
+Graph.prototype.removeNode = function (coordinates) {
+  const node = JSON.stringify(coordinates);
 
   if (this.nodes.has(node)) {
     this.nodes.get(node).forEach(edgeNode => {
@@ -48,4 +48,10 @@ Graph.prototype.removeNode = function (position) {
     });
     this.nodes.delete(node);
   }
+};
+
+Graph.prototype.contains = function (coordinates) {
+  const node = JSON.stringify(coordinates);
+
+  return this.nodes.has(node);
 };


### PR DESCRIPTION
## 개요
- 리덕스 `edgeLinkSlice`로 `isLink`, `linkEdge` 상태 관리 및 로거 추가
- 오토 스냅 `Throttle`로 최적화
- Graph에 `contains` 메소드 추가
- `getPathPositions` 함수 이름을 `getUsablePath`로 변경
- `getUsablePath` 알고리즘 시간 복잡도 개선 (기존 `O(n^2)`에서 `O(n)`으로 변경)
-  `connectEdge` 함수 기능 구현

## 작업 내용
- 플레이어가 패러독스를 만들었을 때만 패스가 이어지도록 구현해야 하기 때문에 링크가 이어진 상태 `isLink`를 리덕스로 관리하도록 구현했습니다.
- `linkEdge`를 통해 패러독스가 이어진 엣지 정보를 리덕스로 관리하도록 구현했습니다.
- 기존 오토 스냅이 useFrame을 사용하여 1초에 수십 번의 렌더링이 이루어져 상태값이 계속 바뀌어 `Throttle`로 제어하도록 구현했습니다.
```javascript
const throttled = (callback, delay) => {
  const lastRun = useRef(Date.now());

  useFrame(() => {
    if (Date.now() - lastRun.current >= delay) {
      callback();
      lastRun.current = Date.now();
    }
  });
};
```
- 오토 스냅에서 패러독스가 이루어졌을 때 리렌더링으로 `isLink`의 상태 값이 계속 바뀌는 문제를 확인하고 `useRef`로 조건 변수를 잡아 리렌더링이 되어도 값을 계속 추적하여 리덕스 상태를 한 번만 업데이트 하도록 로직 수정하였습니다.
```javascript
const prevInRange = useRef(null);

if (prevInRange.current !== inRange) {
  prevInRange.current = inRange;
  dispatch(setIsLink(inRange));
  dispatch(setLinkEdge(linkEdge));
}
```
- Graph에 contains 메소드를 구현했습니다.
- 기존 `getPathPositions` 함수 이름을 `getUsablePath`로 변경하고 알고리즘 시간 복잡도를 O(n^2)에서 O(n)으로 줄이도록 개선했습니다.
기존에는 `filter` 메소드 안에서 `some`을 사용하여 이중 반복이 되었는데, 자료 구조 Set을 이용해 TopCube 검색 속도를 줄였습니다.

```javascript
function getUsablePath(targetY, coordinates) {
  const coordinateSet = new Set(coordinates.map(c => c.join(",")));

  return coordinates.filter(coordinate => {
    const topCubeCoordinates = [
      coordinate[0],
      coordinate[1] + 1,
      coordinate[2],
    ];

    return (
      coordinate[1] === targetY &&
      !coordinateSet.has(topCubeCoordinates.join(","))
    );
  });
}
```
- connectEdge 함수를 통해 isLink가 true가 됐을 때, 오토 스냅 된 엣지 정보인 edgeFrom, edgeTo의 큐브 엣지 좌표로 패러독스가 이루어지는 큐브 좌표를 찾고, 이어지는 곳의 패스를 추가적으로 만들어 붙이는 로직을 구현했습니다.


<img width="324" alt="스크린샷 2023-03-24 오전 12 58 01" src="https://user-images.githubusercontent.com/106433812/227269344-dd350aee-bfe4-49fd-8959-a478bbcce9b4.png">

## 특이 사항
엣지끼리 링크가 된 후, 다시 언링크가 되면 플레이어 오브젝트의 위치에 따라 길을 새로 만들어야 하는데, 플레이어 오브젝트 키 컨트롤 구현하면서 같이 하겠습니다.
