### PR TITLE
feat: stage2 구현

### DIFF
--- a/src/components/objects/LocationMarker.js
+++ b/src/components/objects/LocationMarker.js
@@ -45,7 +45,7 @@ export default function LocationMarker({ position, rotation }) {
       </mesh>
       <mesh
         ref={innerCircleRef}
-        position={[position[0], position[1] + 0.01, position[2]]}
+        position={[position[0], position[1] + 0.51, position[2]]}
         rotation={rotation}
       >
         <planeGeometry args={[1, 1]} />

--- a/src/components/objects/TutorialGuide.js
+++ b/src/components/objects/TutorialGuide.js
@@ -9,7 +9,7 @@ export default function TutorialGuide({
   position,
   rotation,
   scale,
-  setEnableMouseRotation,
+  setEnableCameraRotation,
 }) {
   const dispatch = useDispatch();
   const isLinked = useSelector(state => state.edgeLink.isLinked);
@@ -80,7 +80,7 @@ export default function TutorialGuide({
       setCurrentMission(missions.mission4);
       setCurrentKeydown(keydownGuides.key);
       setCurrentClick(clickGuides.mouseLeft);
-      setEnableMouseRotation(true);
+      setEnableCameraRotation(true);
     }
   }, [currentPosition]);
 

--- a/src/components/stages/StageOne.js
+++ b/src/components/stages/StageOne.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { Canvas } from "@react-three/fiber";
 import {
@@ -36,7 +36,7 @@ export default function StageOne() {
       <Canvas>
         <OrthographicCamera
           makeDefault
-          position={[50, 50, 50]}
+          position={[-50, 50, 50]}
           fov={50}
           near={0.01}
           far={1000}
@@ -69,10 +69,7 @@ export default function StageOne() {
           path={path}
         />
         <Hedgehog position={[4, 8.4, 4]} scale={8} />
-        <LocationPointer
-          position={stageOneCoordinates.arrival}
-          color="yellow"
-        />
+        <LocationPointer position={stageOneCoordinates.arrival} color="navy" />
         <LocationMarker
           position={stageOneCoordinates.arrival}
           rotation={[1.5 * Math.PI, 0, 0]}
@@ -80,7 +77,6 @@ export default function StageOne() {
         {stageOneCoordinates.linkEdges.map(linkEdge => (
           <LinkEdge key={linkEdge.key} linkEdge={linkEdge} />
         ))}
-
         {stageOneCoordinates.linkEdges.map(linkEdge => (
           <AutoSnap
             key={linkEdge.id}

--- a/src/components/stages/StageTwo.js
+++ b/src/components/stages/StageTwo.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { Canvas } from "@react-three/fiber";
 import {
@@ -9,15 +9,17 @@ import {
 
 import stageTwoCoordinates from "../../data/stageTwoCoordinates.json";
 import CubeElement from "../objects/CubeElement";
-import GameMenu from "../menus/GameMenu";
-import BackgroundMusic from "../music/BackgroundMusic";
+
 import Player from "../objects/Player";
-import usePath from "../../hooks/usePath";
+import Hedgehog from "../objects/Hedgehog";
 import LocationMarker from "../objects/LocationMarker";
 import LocationPointer from "../objects/LocationPointer";
+import usePath from "../../hooks/usePath";
+import LinkEdge from "../objects/LinkEdge";
 import AutoSnap from "../../utils/AutoSnap";
 import { setCurrentCoordinates } from "../../redux/currentCoordinatesSlice";
-import LinkEdge from "../objects/LinkEdge";
+import GameMenu from "../menus/GameMenu";
+import BackgroundMusic from "../music/BackgroundMusic";
 
 export default function StageTwo() {
   const dispatch = useDispatch();
@@ -32,7 +34,6 @@ export default function StageTwo() {
 
   return (
     <>
-      <BackgroundMusic />
       <Canvas>
         <OrthographicCamera
           makeDefault
@@ -55,26 +56,12 @@ export default function StageTwo() {
           blur={2}
           far={0.8}
         />
-        {/* <Axis /> */}
         {stageTwoCoordinates.cubes.positions.map(position => (
           <CubeElement
             key={position.id}
             position={position.coordinate}
             scale={0.5}
-            color="indianred"
-          />
-        ))}
-        {stageTwoCoordinates.linkEdges.map(linkEdge => (
-          <LinkEdge key={linkEdge.key} linkEdge={linkEdge} />
-        ))}
-
-        <LocationPointer position={[4, 5.5, 3]} color="yellow" />
-        <LocationMarker position={[4, 5, 3]} rotation={[1.5 * Math.PI, 0, 0]} />
-        {stageTwoCoordinates.linkEdges.map(linkEdge => (
-          <AutoSnap
-            key={linkEdge.id}
-            linkSensitivity={0.05}
-            linkEdge={linkEdge}
+            color="#03a9f4"
           />
         ))}
         <Player
@@ -82,9 +69,35 @@ export default function StageTwo() {
           rotation={[0, 1.5 * Math.PI, 0]}
           path={path}
         />
+        <Hedgehog position={[3, 5.4, 5]} scale={8} />
+        <Hedgehog position={[3, 5.4, 4]} scale={8} />
+        <Hedgehog position={[4, 5.4, 4]} scale={8} />
+        <Hedgehog position={[5, 5.4, 4]} scale={8} />
+        <Hedgehog position={[4, 5.4, 3]} scale={8} />
+        <Hedgehog position={[4, 5.4, 4]} scale={8} />
+        <Hedgehog position={[4, 5.4, 5]} scale={8} />
+        <LocationPointer
+          position={stageTwoCoordinates.arrival}
+          color="indianred"
+        />
+        <LocationMarker
+          position={stageTwoCoordinates.arrival}
+          rotation={[1.5 * Math.PI, 0, 0]}
+        />
+        {stageTwoCoordinates.linkEdges.map(linkEdge => (
+          <LinkEdge key={linkEdge.key} linkEdge={linkEdge} />
+        ))}
+        {stageTwoCoordinates.linkEdges.map(linkEdge => (
+          <AutoSnap
+            key={linkEdge.id}
+            linkSensitivity={0.05}
+            linkEdge={linkEdge}
+          />
+        ))}
         <OrbitControls />
       </Canvas>
       <GameMenu />
+      <BackgroundMusic />
     </>
   );
 }

--- a/src/components/stages/StageZero.js
+++ b/src/components/stages/StageZero.js
@@ -19,7 +19,7 @@ import TutorialGuide from "../objects/TutorialGuide";
 import { setCurrentCoordinates } from "../../redux/currentCoordinatesSlice";
 
 export default function StageZero() {
-  const [enableMouseRotation, setEnableMouseRotation] = useState(false);
+  const [enableCameraRotation, setEnableCameraRotation] = useState(false);
 
   const dispatch = useDispatch();
   const coordinates = stageZeroCoordinates.cubes.positions.map(
@@ -34,7 +34,7 @@ export default function StageZero() {
   return (
     <>
       <Canvas>
-        {enableMouseRotation ? (
+        {enableCameraRotation ? (
           <OrthographicCamera
             makeDefault
             position={[50, 50, 50]}
@@ -79,11 +79,17 @@ export default function StageZero() {
           position={[-5, 0, 1]}
           rotation={[1.5 * Math.PI, 0, 0]}
           scale={5}
-          setEnableMouseRotation={setEnableMouseRotation}
+          setEnableCameraRotation={setEnableCameraRotation}
         />
 
-        <LocationPointer position={[0, 5.5, 0]} color="yellow" />
-        <LocationMarker position={[0, 5, 0]} rotation={[1.5 * Math.PI, 0, 0]} />
+        <LocationPointer
+          position={stageZeroCoordinates.arrival}
+          color="yellow"
+        />
+        <LocationMarker
+          position={stageZeroCoordinates.arrival}
+          rotation={[1.5 * Math.PI, 0, 0]}
+        />
         {stageZeroCoordinates.linkEdges.map(linkEdge => (
           <AutoSnap
             key={linkEdge.id}
@@ -96,7 +102,7 @@ export default function StageZero() {
           rotation={[0, 1.5 * Math.PI, 0]}
           path={path}
         />
-        {enableMouseRotation && <OrbitControls />}
+        {enableCameraRotation && <OrbitControls />}
       </Canvas>
       <SkipMenu />
     </>

--- a/src/data/stageOneCoordinates.json
+++ b/src/data/stageOneCoordinates.json
@@ -40,7 +40,7 @@
   },
   "linkEdges": [
     {
-      "id": "stageZero-linkEdge-1",
+      "id": "stageOne-linkEdge-1",
       "edgeFrom": {
         "pointA": [-0.5, 6, 0.5],
         "pointB": [0.5, 6, 0.5]
@@ -53,14 +53,14 @@
       "thickness": 3
     },
     {
-      "id": "stageZero-linkEdge-2",
+      "id": "stageOne-linkEdge-2",
       "edgeFrom": {
-        "pointA": [1.5, 6, 0.5],
-        "pointB": [1.5, 6, -0.5]
+        "pointA": [3.5, 7, 3.5],
+        "pointB": [3.5, 7, 4.5]
       },
       "edgeTo": {
-        "pointA": [3.5, 8, 3.5],
-        "pointB": [3.5, 8, 4.5]
+        "pointA": [1.5, 6, 0.5],
+        "pointB": [1.5, 6, -0.5]
       },
       "color": "red",
       "thickness": 3

--- a/src/data/stageTwoCoordinates.json
+++ b/src/data/stageTwoCoordinates.json
@@ -1,138 +1,84 @@
 {
-  "departure": [0, 0.5, 1],
-  "arrival": [4, 0.5, 4],
+  "departure": [0, 0.5, 4],
+  "arrival": [4, 0.5, 8],
+
   "cubes": {
     "positions": [
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 7.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 6.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 5.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 4.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 3.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 2.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [0, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [2, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [4, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [5, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [7, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 7.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 6.5] },
+      { "id": "stageTwo-cube-1", "coordinate": [4, 0.5, 0] },
+      { "id": "stageTwo-cube-2", "coordinate": [8, 0.5, 4] },
+      { "id": "stageTwo-cube-3", "coordinate": [4, 0.5, 8] },
+      { "id": "stageTwo-cube-4", "coordinate": [0, 0.5, 4] },
 
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 4.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 3.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 2.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, 0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -7, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [0, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [2, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [4, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [5, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -7, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [7, -7, 8.5] },
+      { "id": "stageTwo-cube-5", "coordinate": [3, 3.5, 3] },
+      { "id": "stageTwo-cube-6", "coordinate": [4, 3.5, 3] },
+      { "id": "stageTwo-cube-7", "coordinate": [5, 3.5, 3] },
+      { "id": "stageTwo-cube-8", "coordinate": [3, 3.5, 4] },
+      { "id": "stageTwo-cube-9", "coordinate": [4, 3.5, 4] },
+      { "id": "stageTwo-cube-10", "coordinate": [5, 3.5, 4] },
+      { "id": "stageTwo-cube-11", "coordinate": [3, 3.5, 5] },
+      { "id": "stageTwo-cube-12", "coordinate": [4, 3.5, 5] },
+      { "id": "stageTwo-cube-13", "coordinate": [5, 3.5, 5] },
 
-      { "id": "stageTwo-cube-1", "coordinate": [8, -8, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -9, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -10, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -11, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -12, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [8, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -8, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -9, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -10, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -11, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -12, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 8.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -8, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -8.5, -0.5] },
+      { "id": "stageTwo-cube-14", "coordinate": [3, 4.5, 4] },
+      { "id": "stageTwo-cube-15", "coordinate": [4, 4.5, 3] },
+      { "id": "stageTwo-cube-16", "coordinate": [4, 4.5, 4] },
+      { "id": "stageTwo-cube-17", "coordinate": [4, 4.5, 5] },
+      { "id": "stageTwo-cube-18", "coordinate": [5, 4.5, 4] },
 
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 7.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 6.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 5.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 4.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 3.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 2.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, 0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [-1, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [0, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [2, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [4, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [5, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -13, -0.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [7, -13, -0.5] },
-
-      { "id": "stageTwo-cube-1", "coordinate": [5, -9, 5.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [5, -9, 4.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [5, -9, 3.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [4, -9, 5.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -9, 5.5] },
-
-      { "id": "stageTwo-cube-1", "coordinate": [3, -9, 4.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -9, 3.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [4, -9, 3.5] },
-
-      { "id": "stageTwo-cube-1", "coordinate": [1, -9.5, 6.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -10, 6.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11, 6.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 6.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -11.5, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -11, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -10, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [6, -9.5, 1.5] },
-
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 5.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 4.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 3.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 5.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 2.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [5, -11.5, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [4, -11.5, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [3, -11.5, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [2, -11.5, 1.5] },
-      { "id": "stageTwo-cube-1", "coordinate": [1, -11.5, 1.5] },
-
-      { "id": "stageTwo-cube-1", "coordinate": [7, -13, 1.2] },
-      { "id": "stageTwo-cube-1", "coordinate": [0, -12.8, 7] }
+      { "id": "stageTwo-cube-19", "coordinate": [3, 4.5, 5] }
     ]
   },
   "linkEdges": [
     {
-      "id": "stageZero-linkEdge-1",
+      "id": "stageTwo-linkEdge-1",
       "edgeFrom": {
-        "pointA": [-0.5, 5, 0.5],
-        "pointB": [0.5, 5, 0.5]
+        "pointA": [2.5, 4, 2.5],
+        "pointB": [2.5, 4, 3.5]
       },
       "edgeTo": {
-        "pointA": [3.5, 1, 3.5],
-        "pointB": [4.5, 1, 3.5]
+        "pointA": [0.5, 1, 3.5],
+        "pointB": [0.5, 1, 4.5]
       },
       "color": "blue",
       "thickness": 3
     },
     {
-      "id": "stageZero-linkEdge-2",
+      "id": "stageTwo-linkEdge-2",
       "edgeFrom": {
-        "pointA": [0.5, 5, 0.5],
-        "pointB": [0.5, 5, -0.5]
+        "pointA": [2.5, 4, 2.5],
+        "pointB": [3.5, 4, 2.5]
       },
       "edgeTo": {
-        "pointA": [3.5, 8, 3.5],
-        "pointB": [3.5, 8, 4.5]
+        "pointA": [3.5, 1, 0.5],
+        "pointB": [4.5, 1, 0.5]
       },
       "color": "red",
+      "thickness": 3
+    },
+    {
+      "id": "stageTwo-linkEdge-2",
+      "edgeFrom": {
+        "pointA": [5.5, 4, 2.5],
+        "pointB": [5.5, 4, 3.5]
+      },
+      "edgeTo": {
+        "pointA": [7.5, 1, 3.5],
+        "pointB": [7.5, 1, 4.5]
+      },
+      "color": "purple",
+      "thickness": 3
+    },
+    {
+      "id": "stageTwo-linkEdge-2",
+      "edgeFrom": {
+        "pointA": [4.5, 4, 5.5],
+        "pointB": [5.5, 4, 5.5]
+      },
+      "edgeTo": {
+        "pointA": [3.5, 1, 7.5],
+        "pointB": [4.5, 1, 7.5]
+      },
+      "color": "green",
       "thickness": 3
     }
   ]

--- a/src/data/stageZeroCoordinates.json
+++ b/src/data/stageZeroCoordinates.json
@@ -1,6 +1,6 @@
 {
   "departure": [0, 0.5, 1],
-  "arrival": [4, 0.5, 4],
+  "arrival": [0, 4.5, 0],
   "cubes": {
     "positions": [
       { "id": "stageZero-cube-1", "coordinate": [0, 4.5, 0] },


### PR DESCRIPTION
## 개요
- 게임모드의 `StageTwo`를 구현하였습니다.
- 튜토리얼을 완료한 유저가 게임을 클리어하기 위해 해결해야 할 챌린지들을 배치하여 게임 스테이지를 기획, 구성하였습니다.
- `edge play`를 제한하기 위해 해당위치를 지나갈 수 없도록 오브젝트 (고슴도치)를 구현하여 배치하였습니다.
- 각 stage 별로 다른 색상으로 맵 구성 `cube`와 `location pointer`를 설정하였으며, `플레이어 오브젝트`와 `location pointer`의 위치를 데이터파일에서 직접 불러오도록 설정하였습니다.

## 작업 내용
![image](https://user-images.githubusercontent.com/105766632/227879885-5042d3a0-0faa-45b6-b465-3e598082ee94.png)
![image](https://user-images.githubusercontent.com/105766632/227879927-e5bed622-6fe0-4140-a565-72c02251ed8b.png)
![image](https://user-images.githubusercontent.com/105766632/227879956-e8e8d56d-cbae-48ac-897f-f5d825ed28c9.png)

## 특이 사항
- `linkEdge` 자동 계산 알고리즘과 관련, 특정 edge에서 계산이 잘못되는 버그가 있었습니다.
- Link계산식은 각 축의 기준점에 따라 달라져야하며 +/- xyz축에 대해 총 8가지 경우의 수가 있습니다. (이미지 참조)
- 현재의 공식이 모든 상황에서 적용되기 위해, 다음의 방법을 통해 경우의 수를 1가지로 줄였습니다. 
- 데이터 파일에서 `linkEdge` 설정기준:
1. 각 엣지는 `xz평면`을 기준으로 평행할 것
2. `edgeFrom`의 좌표들의 y값은 `edgeTo`의 좌표들의 y값보다 크게 설정할 것

